### PR TITLE
Remove the notion of imported type

### DIFF
--- a/src/language/typical-validator.ts
+++ b/src/language/typical-validator.ts
@@ -5,8 +5,8 @@ import {
   type Declaration,
   type Field,
   type Deleted,
-  isImportedType,
   Schema,
+  isCustomType,
 } from "./generated/ast.js";
 import type { TypicalServices } from "./typical-module.js";
 import { dirname, join } from "path";
@@ -103,7 +103,7 @@ export class TypicalValidator {
 
     for (const decl of imp.$container.declarations) {
       for (const field of decl.fields) {
-        if (isImportedType(field.type) && field.type.module === importIdent) {
+        if (isCustomType(field.type) && field.type.module === importIdent) {
           return true;
         }
       }
@@ -150,7 +150,7 @@ export class TypicalValidator {
   }
 
   importedTypeExists(field: Field, accept: ValidationAcceptor): void {
-    if (isImportedType(field.type)) {
+    if (isCustomType(field.type)) {
       const { module, type } = field.type;
       const currentUri = field.$container.$container.$document!.uri;
 
@@ -189,7 +189,7 @@ export class TypicalValidator {
       // Check if the type exists in the imported document
       const typeExists = (
         importedDocument.parseResult.value as Schema
-      ).declarations.some((decl) => decl.name === type);
+      ).declarations.some((decl) => decl.name === type.ref?.name);
 
       if (!typeExists) {
         accept(

--- a/src/language/typical.langium
+++ b/src/language/typical.langium
@@ -21,16 +21,13 @@ fragment Rule:
     rule=('asymmetric' | 'optional' | 'required');
 
 fragment Type:
-	type=('String' | 'Bool' | 'Bytes' | 'F64' | 'S64' | 'U64' | 'Unit' | ArrayType | CustomType | ImportedType);
+	type=('String' | 'Bool' | 'Bytes' | 'F64' | 'S64' | 'U64' | 'Unit' | ArrayType | CustomType);
 
 ArrayType:
     '[' Type ']';
 
 CustomType:
-    ref=[Declaration:ID];
-
-ImportedType:
-    module=ID '.' type=ID;
+    (module=ID '.')? type=[Declaration:ID];
 
 terminal ID: /[_a-zA-Z][\w_]*/;
 terminal PATH: /'[\w_\/\.-]*'/;


### PR DESCRIPTION
As I was fleshing out the [type](https://just-be.dev/rc/building-a-language-server-for-typical#type) explanation of Typical, I realized typical's [`TypeVariant`](https://github.com/stepchowfun/typical/blob/c575520dc9df5d91d5dced702b6c1b8171a78dd1/src/schema.rs#L74C1-L84C2) doesn't explicitly include an import type, it's just part of the custom type. It was simple enough to consolidate them. 