### PR TITLE
Stop ignoring syntaxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@
 node_modules/
 out/
 src/language/generated/
-syntaxes/
 dist/
+*.tsbuildinfo

--- a/src/syntaxes/typical.monarch.ts
+++ b/src/syntaxes/typical.monarch.ts
@@ -1,0 +1,26 @@
+// Monarch syntax highlighting for the typical language.
+export default {
+    keywords: [
+        'Bool','Bytes','F64','S64','String','U64','Unit','as','asymmetric','choice','deleted','import','optional','required','struct'
+    ],
+    operators: [
+        '.',':','='
+    ],
+    symbols: /\.|:|=|\[|\]|\{|\}/,
+
+    tokenizer: {
+        initial: [
+            { regex: /[_a-zA-Z][\w_]*/, action: { cases: { '@keywords': {"token":"keyword"}, '@default': {"token":"ID"} }} },
+            { regex: /'[\w_\/\.-]*'/, action: {"token":"PATH"} },
+            { regex: /[0-9][\w_]*/, action: { cases: { '@keywords': {"token":"keyword"}, '@default': {"token":"number"} }} },
+            { include: '@whitespace' },
+            { regex: /@symbols/, action: { cases: { '@operators': {"token":"operator"}, '@default': {"token":""} }} },
+        ],
+        whitespace: [
+            { regex: /#[^\n\r]*/, action: {"token":"comment"} },
+            { regex: /\s+/, action: {"token":"white"} },
+        ],
+        comment: [
+        ],
+    }
+};

--- a/syntaxes/typical.tmLanguage.json
+++ b/syntaxes/typical.tmLanguage.json
@@ -1,0 +1,32 @@
+{
+  "name": "typical",
+  "scopeName": "source.typical",
+  "fileTypes": [
+    ".t"
+  ],
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "name": "keyword.control.typical",
+      "match": "\\b(Bool|Bytes|F64|S64|String|U64|Unit|as|asymmetric|choice|deleted|import|optional|required|struct)\\b"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "begin": "#",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.typical"
+            }
+          },
+          "end": "(?=$)",
+          "name": "comment.line.typical"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Previously the language syntaxes were ignored. This is understandable given that they're generated, but I want to track their changes as the language updates.