### PR TITLE
Implement scope tracking

### DIFF
--- a/src/language/typical-module.ts
+++ b/src/language/typical-module.ts
@@ -15,6 +15,10 @@ import {
   TypicalValidator,
   registerValidationChecks,
 } from "./typical-validator.js";
+import {
+  TypicalScopeComputation,
+  TypicalScopeProvider,
+} from "./typical-scope.js";
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -42,6 +46,10 @@ export const TypicalModule: Module<
 > = {
   validation: {
     TypicalValidator: (services) => new TypicalValidator(services),
+  },
+  references: {
+    ScopeComputation: (services) => new TypicalScopeComputation(services),
+    ScopeProvider: (services) => new TypicalScopeProvider(services),
   },
 };
 

--- a/src/language/typical-scope.ts
+++ b/src/language/typical-scope.ts
@@ -1,0 +1,53 @@
+import {
+  AstNode,
+  AstNodeDescription,
+  AstUtils,
+  DefaultScopeComputation,
+  DefaultScopeProvider,
+  EMPTY_SCOPE,
+  LangiumDocument,
+  ReferenceInfo,
+  Scope,
+} from "langium";
+import { Declaration, isCustomType, Schema } from "./generated/ast.js";
+import { extractModuleFromImport } from "./utils.js";
+import { dirname, join } from "path";
+
+export class TypicalScopeComputation extends DefaultScopeComputation {
+  override async computeExports(
+    document: LangiumDocument<AstNode>
+  ): Promise<AstNodeDescription[]> {
+    const schema = document.parseResult.value as Schema;
+    return schema.declarations.map((d) =>
+      this.descriptions.createDescription(d, d.name)
+    );
+  }
+}
+
+export class TypicalScopeProvider extends DefaultScopeProvider {
+  override getScope(context: ReferenceInfo): Scope {
+    if (isCustomType(context.container) && context.container.module) {
+      const { module } = context.container;
+      return this.resolveImportedScope(context, module);
+    }
+    return EMPTY_SCOPE;
+  }
+
+  private resolveImportedScope(context: ReferenceInfo, module: string): Scope {
+    const document = AstUtils.getDocument(context.container);
+    const schema = document.parseResult.value as Schema;
+    for (const imp of schema.imports) {
+      const importModule = extractModuleFromImport(imp);
+      if (importModule === module) {
+        const currentUri = document.uri;
+        const currentDir = dirname(currentUri.path);
+        const importUri = join(currentDir, imp.path.slice(1, -1));
+        const uri = currentUri.with({ path: importUri });
+        return this.createScope(
+          this.indexManager.allElements(Declaration, new Set([uri.toString()]))
+        );
+      }
+    }
+    return EMPTY_SCOPE;
+  }
+}

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -1,0 +1,8 @@
+import { basename } from "path";
+import { Import } from "./generated/ast.js";
+
+export const extractModuleFromImport = (importNode: Import): string => {
+  return importNode.alias
+    ? importNode.alias
+    : basename(importNode.path.slice(1, -1), ".t");
+};


### PR DESCRIPTION
Adds proper scope resolution for custom types via the typical-scope module. The scope computation marks all declarations as exports and the scope provider walks all custom types and resolves them from their relevant module.