### PR TITLE
Add semantic highlighting

### DIFF
--- a/src/language/typical-module.ts
+++ b/src/language/typical-module.ts
@@ -19,6 +19,7 @@ import {
   TypicalScopeComputation,
   TypicalScopeProvider,
 } from "./typical-scope.js";
+import { TypicalSemanticTokenProvider } from "./typical-token-provider.js";
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -50,6 +51,10 @@ export const TypicalModule: Module<
   references: {
     ScopeComputation: (services) => new TypicalScopeComputation(services),
     ScopeProvider: (services) => new TypicalScopeProvider(services),
+  },
+  lsp: {
+    SemanticTokenProvider: (services) =>
+      new TypicalSemanticTokenProvider(services),
   },
 };
 

--- a/src/language/typical-token-provider.ts
+++ b/src/language/typical-token-provider.ts
@@ -1,0 +1,51 @@
+import { AstNode } from "langium";
+import {
+  AbstractSemanticTokenProvider,
+  SemanticTokenAcceptor,
+} from "langium/lsp";
+import { isCustomType, isDeclaration, isImport } from "./generated/ast.js";
+import { SemanticTokenTypes } from "vscode-languageserver";
+
+export class TypicalSemanticTokenProvider extends AbstractSemanticTokenProvider {
+  protected override highlightElement(
+    node: AstNode,
+    acceptor: SemanticTokenAcceptor
+  ): void | undefined | "prune" {
+    if (isImport(node)) {
+      acceptor({
+        node,
+        property: "alias",
+        type: SemanticTokenTypes.class,
+      });
+      acceptor({
+        node,
+        property: "path",
+        type: SemanticTokenTypes.string,
+      });
+      return;
+    }
+
+    if (isCustomType(node)) {
+      acceptor({
+        node,
+        property: "module",
+        type: SemanticTokenTypes.class,
+      });
+      acceptor({
+        node,
+        property: "type",
+        type: SemanticTokenTypes.variable,
+      });
+      return;
+    }
+
+    if (isDeclaration(node)) {
+      acceptor({
+        node,
+        property: "name",
+        type: SemanticTokenTypes.variable,
+      });
+      return;
+    }
+  }
+}


### PR DESCRIPTION
It's easy enough to add [semantic highlighting](https://langium.org/docs/recipes/keywords-as-identifiers/#step-2-change-the-semantic-type-of-the-resulting-token) so I went ahead and did that. I was tinkering about with just highlighting the identifier of the path string, but it sort of looks ugly and the implementation sucked so I removed it. 

<img title="before" src="https://github.com/user-attachments/assets/8e7383ed-a095-415b-9a42-972b225e9378" width="300px" align="left"/>
‎
<img title="after" src="https://github.com/user-attachments/assets/790aef67-96b9-4811-8e7d-be62a166a726" width="300px"/>
