### PR TITLE
Resolve build not finding commonjs bundle

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -1,54 +1,54 @@
 //@ts-check
-import * as esbuild from 'esbuild';
+import * as esbuild from "esbuild";
 
-const watch = process.argv.includes('--watch');
-const minify = process.argv.includes('--minify');
+const watch = process.argv.includes("--watch");
+const minify = process.argv.includes("--minify");
 
-const success = watch ? 'Watch build succeeded' : 'Build succeeded';
+const success = watch ? "Watch build succeeded" : "Build succeeded";
 
 function getTime() {
-    const date = new Date();
-    return `[${`${padZeroes(date.getHours())}:${padZeroes(date.getMinutes())}:${padZeroes(date.getSeconds())}`}] `;
+  const date = new Date();
+  return `[${`${padZeroes(date.getHours())}:${padZeroes(
+    date.getMinutes()
+  )}:${padZeroes(date.getSeconds())}`}] `;
 }
 
 function padZeroes(i) {
-    return i.toString().padStart(2, '0');
+  return i.toString().padStart(2, "0");
 }
 
-const plugins = [{
-    name: 'watch-plugin',
+const plugins = [
+  {
+    name: "watch-plugin",
     setup(build) {
-        build.onEnd(result => {
-            if (result.errors.length === 0) {
-                console.log(getTime() + success);
-            }
-        });
+      build.onEnd((result) => {
+        if (result.errors.length === 0) {
+          console.log(getTime() + success);
+        }
+      });
     },
-}];
+  },
+];
 
 const ctx = await esbuild.context({
-    // Entry points for the vscode extension and the language server
-    entryPoints: ['src/extension/main.ts', 'src/language/main.ts'],
-    outdir: 'out',
-    bundle: true,
-    target: "ES2017",
-    // VSCode's extension host is still using cjs, so we need to transform the code
-    format: 'cjs',
-    // To prevent confusing node, we explicitly use the `.cjs` extension
-    outExtension: {
-        '.js': '.cjs'
-    },
-    loader: { '.ts': 'ts' },
-    external: ['vscode'],
-    platform: 'node',
-    sourcemap: !minify,
-    minify,
-    plugins
+  // Entry points for the vscode extension and the language server
+  entryPoints: ["src/extension/main.ts", "src/language/main.ts"],
+  outdir: "out",
+  bundle: true,
+  target: "ES2017",
+  format: "cjs",
+  outExtension: { ".js": ".cjs.js" },
+  loader: { ".ts": "ts" },
+  external: ["vscode"],
+  platform: "node",
+  sourcemap: !minify,
+  minify,
+  plugins,
 });
 
 if (watch) {
-    await ctx.watch();
+  await ctx.watch();
 } else {
-    await ctx.rebuild();
-    ctx.dispose();
+  await ctx.rebuild();
+  ctx.dispose();
 }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,8 @@
     "out",
     "src"
   ],
-  "type": "module",
   "scripts": {
-    "build": "npm run langium:generate && tsc -b tsconfig.src.json && node esbuild.mjs",
+    "build": "npm run langium:generate && tsc -b tsconfig.src.json --noEmit && node esbuild.mjs",
     "watch": "concurrently -n tsc,esbuild -c blue,yellow \"tsc -b tsconfig.src.json --watch\" \"node esbuild.mjs --watch\"",
     "langium:generate": "langium generate",
     "langium:watch": "langium generate --watch",
@@ -85,6 +84,7 @@
   "activationEvents": [
     "onLanguage:typical"
   ],
+  "type": "commonjs",
   "main": "./out/extension/main.cjs",
   "publisher": "just-be",
   "author": {


### PR DESCRIPTION
The extension was failing to activate due to it not finding the common.js file _and_ resolving it as an ESM file. This should fix both issues. 