### PR TITLE
Fix crash due to declaration having no name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## v0.0.3
+
+- Fix a crash loop that occured when a declaration didn't yet have a name
+
+## v0.0.2
+
+- Fix bundling issues that caused LSP to not initialize
+
+## v0.0.1
+
+Inital release
+
+- Adds syntax highlighting
+- Adds semantic highlighting
+- Adds basic validation

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "typical-tools",
   "description": "A language server for Typical, a protobuf-like language",
   "repository": "https://github.com/zephraph/typical-tools",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "files": [
     "bin",
     "out",

--- a/src/language/typical-scope.ts
+++ b/src/language/typical-scope.ts
@@ -18,9 +18,9 @@ export class TypicalScopeComputation extends DefaultScopeComputation {
     document: LangiumDocument<AstNode>
   ): Promise<AstNodeDescription[]> {
     const schema = document.parseResult.value as Schema;
-    return schema.declarations.map((d) =>
-      this.descriptions.createDescription(d, d.name)
-    );
+    return schema.declarations
+      .filter((d) => d.name)
+      .map((d) => this.descriptions.createDescription(d, d.name));
   }
 }
 

--- a/test/parsing/parsing.test.ts
+++ b/test/parsing/parsing.test.ts
@@ -47,3 +47,8 @@ test("full example with imports", async () => {
   expect(document.parseResult.lexerErrors).toHaveLength(0);
   expect(document.parseResult.parserErrors).toHaveLength(0);
 });
+
+test("decl without name shouldn't throw", async () => {
+  const { parse } = await init();
+  expect(parse(`struct`)).resolves.not.toThrowError();
+});


### PR DESCRIPTION
```
/Users/just-be/.cursor/extensions/just-be.typical-tools-0.0.2/out/language/main.cjs.js:26752
      throw new Error(`Node at path ${path} has no name.`);
            ^

Error: Node at path /declarations@0 has no name.
    at DefaultAstNodeDescriptionProvider.createDescription (/Users/just-be/.cursor/extensions/just-be.typical-tools-0.0.2/out/language/main.cjs.js:26752:13)
    at /Users/just-be/.cursor/extensions/just-be.typical-tools-0.0.2/out/language/main.cjs.js:31119:32
    at Array.map (<anonymous>)
    at TypicalScopeComputation.computeExports (/Users/just-be/.cursor/extensions/just-be.typical-tools-0.0.2/out/language/main.cjs.js:31118:32)
    at DefaultIndexManager.updateContent (/Users/just-be/.cursor/extensions/just-be.typical-tools-0.0.2/out/language/main.cjs.js:27287:65)
    at /Users/just-be/.cursor/extensions/just-be.typical-tools-0.0.2/out/language/main.cjs.js:27083:111
    at DefaultDocumentBuilder.runCancelable (/Users/just-be/.cursor/extensions/just-be.typical-tools-0.0.2/out/language/main.cjs.js:27119:13)
    at async DefaultDocumentBuilder.buildDocuments (/Users/just-be/.cursor/extensions/just-be.typical-tools-0.0.2/out/language/main.cjs.js:27083:5)
    at async DefaultDocumentBuilder.update (/Users/just-be/.cursor/extensions/just-be.typical-tools-0.0.2/out/language/main.cjs.js:27028:5)
    at async /Users/just-be/.cursor/extensions/just-be.typical-tools-0.0.2/out/language/main.cjs.js:28161:24

Node.js v20.9.0
[Error - 2:45:36 PM] Server process exited with code 1.
[Error - 2:45:36 PM] The Typical server crashed 5 times in the last 3 minutes. The server will not be restarted. See the output for more information.
```

I ran into this error loop that caused the typical tools server to crash repeatedly and then refuse to come back up. Essentially while you're creating a new declaration it may be in the state where the name itself isn't even written yet. If the name property isn't yet present, we don't want to calculate the scope for it. 