### PR TITLE
Fix publish failure; improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
+      - name: Build and package
+        run: npm run package
 
       - name: Run tests
         run: npm test

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@codingame/esbuild-import-meta-url-plugin": "~1.0.2",
     "@types/node": "^18.0.0",
-    "@types/vscode": "~1.93.0",
+    "@types/vscode": "^1.67.0",
     "concurrently": "~8.2.1",
     "esbuild": "~0.20.2",
     "http-server": "~14.1.1",


### PR DESCRIPTION
The last [publish step](https://github.com/zephraph/typical-tools/actions/runs/10890374131/job/30218998547) failed because #19 changed the version of vscode types and `vsce` has some sort of validation ensuring the types are in sync. CI didn't catch this because I was only running build and test but _not package_. I've resolved this issue by downgrading the types to match the current expectation and updating CI to run the package step (which runs build under the hood). 